### PR TITLE
lxc/rexec.c: fixed memfd-rexec on android

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -49,12 +49,6 @@ jobs:
 
         meson compile -C build
         sudo /usr/local/bin/ninja -C build install
-        
-    - name: Upload artifacts sysroot
-      uses: actions/upload-artifact@v4.3.1
-      with:
-        name: android-aarch64-deps-shared-api30
-        path: /data/sysroot/*
 
     - name: Upload artifacts lxc
       uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -28,7 +28,7 @@ jobs:
 
         meson setup build \
             -Dprefix=/data/share \
-            -Dinit-script=sysvinit \
+            -Dinit-script=monitd \
             -Druntime-path=/data/local/tmp \
             -Dstrip=true \
             -Dd_lto=true \
@@ -48,3 +48,15 @@ jobs:
             --cross-file aarch64-android-api30.txt
 
         meson compile -C build
+        
+    - name: Upload artifacts sysroot
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: android-aarch64-deps-shared-api30
+        path: /data/sysroot/*
+
+    - name: Upload artifacts lxc
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: android-aarch64-lxc-shared-api30
+        path: /data/share/*

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -48,6 +48,7 @@ jobs:
             --cross-file aarch64-android-api30.txt
 
         meson compile -C build
+        sudo /usr/local/bin/ninja -C build install
         
     - name: Upload artifacts sysroot
       uses: actions/upload-artifact@v4.3.1


### PR DESCRIPTION
not enabled by default